### PR TITLE
[Fix] no_proxy env and service not updated

### DIFF
--- a/hive_builder/playbooks/deploy-services.yml
+++ b/hive_builder/playbooks/deploy-services.yml
@@ -111,7 +111,7 @@
       args: "{{ hostvars[item].hive_command | default(omit) }}"
       # Docker calls it entrypoint, but swarmkit calls it command
       command: "{{ hostvars[item].hive_entrypoint | default(omit) }}"
-      env: "{{ hostvars[item].hive_environment | default({}) | combine(hive_safe_proxy_setting) }}"
+      env: "{{ hive_safe_proxy_setting | combine(hostvars[item].hive_environment | default({})) }}"
       publish: "{{ hostvars[item].hive_ports | default(omit) }}"
       mounts: "{{ hostvars[item].hive_volumes | default(omit) }}"
       labels: >-
@@ -134,7 +134,7 @@
       networks: "{{ hostvars[item].hive_networks | default(groups['networks']) }}"
       force_update: |
         {% set hive_safe_autovars = {'force_update': False} %}
-        {% if hostvars[item].hive_image_name is defined and not (hive_destroy  | default(false)) %}
+        {% if not (hive_destroy  | default(false)) %}
           {%- for process in (hive_safe_ps.results | selectattr('item', 'eq', item) | first).stdout_lines | map('from_json') %}
             {%- set container = hive_safe_container_info.results | selectattr('item.name', 'eq', process.name) | first %}
             {%- set image_id = (hostvars[process.node].hive_safe_pull_result.results | selectattr('item', 'eq', item) | first).image.Id %}


### PR DESCRIPTION
Fixed issues where setting the no_proxy environment variable would be overwritten by the default value and the service would not be updated when an image was downloaded from dockerhub.