### PR TITLE
[Fix] dexec execute the command on the host.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -156,11 +156,11 @@ mother 環境構築直後の build-infra フェーズで Unexpected failure duri
 :対応方法: 仮想環境を作成し、そこに hive-builder をインストールして、仮想環境をアクティベートしてから hiveコマンドを実行してください。
       仮想環境をアクティベートすると、OSには python3 しかインストールされていな状態でも pythonコマンドが利用できます。
 
-異常がないのに zabbix で Some service status are failed のトリガーがあがる
+異常がないのに zabbix で At least one of the services is in a failed state のトリガーがあがる
 ----------------------------------------------------------------------------------------------------------
 :現象:
 
-異常がないのに zabbix で Some service status are failed のトリガーがあがる。
+異常がないのに zabbix で At least one of the services is in a failed state のトリガーがあがる。
 以下のコマンドを実行すると失敗しているサービス名はわかったが、そのサービスはすでに削除されている。
 たとえば、DRBD のボリュームがエラーになった後、 build-volumes -l ボリューム名 -D などで削除した場合、
 以下のように表示される

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ hive-builder ドキュメントページへようこそ
     phases.rst
     swarmextender.rst
     migration.rst
+    zabbix.rst
     repair.rst
     faq.rst
 

--- a/docs/repair.rst
+++ b/docs/repair.rst
@@ -143,7 +143,7 @@ DRBDボリュームのディスク残量
 
 ホスト内サービスの失敗
 =================================
-ホストの中でサービスの実行に失敗し、zabbix から "Problem: Some service status are failed" の警告メッセージが上がる場合があります。
+ホストの中でサービスの実行に失敗し、zabbix から "Problem: At least one of the services is in a failed state" の警告メッセージが上がる場合があります。
 
 この場合、以下のコマンドで失敗しているサービスを特定しその原因を追求して対策を講じてください。
 

--- a/docs/zabbix.rst
+++ b/docs/zabbix.rst
@@ -1,0 +1,46 @@
+========================
+hive 内 zabbixの設定
+========================
+リポジトリサーバではサーバと Swarm サービスを監視する Zabbix が稼働しています。
+この Zabbix の設定方法を示します。
+
+Slack に通知する
+=================================
+Slack に通知する手順を示します。
+
+slack 側の設定
+---------------------------------
+
+１．Application を作成
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+slack に Application を作成してください。
+`Slack の Your Apps <https://api.slack.com/apps>`_ の「Create New App」でアプリケーション「hive_builder_zabbix」を作成してください。この名前は任意のもので構いません。
+
+２．Bots を追加
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Basic InformationのAdd features and functionalityでBotsを選択してください。
+
+３．OAuth & Permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+左メニュー「Features」-「OAuth & Permissions」を選択してください。
+「Scopes」で Add an OAuth Scope を実行して chat: writeを追加してください。
+
+４．Access Token コピー
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+「Bot User OAuth Access Token」の Token 文字列をコピーしておいてください（後ほど Zabbix に設定する）。
+
+hive-builder 設定
+---------------------------------
+
+１．メディアタイプを作成
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+「Administration」-「Media Types」で（標準添付の）「Slack」を開き、「Parameters」で以下３点を修正してください。
+
+- 「bot_token」に、前項でコピーした Token を入力
+- 「channel」に、通知先のチャネル名を入力
+- 「zabbix_url」に、「http://127.0.0.1:10052/」を入力
+
+.. note:: zabbix_url は slack に通知されるメッセージに「Open in Zabbx」というリンクで埋め込まれます。
+          プロキシサーバなどを使用して hive内 zabbix に外部からアクセスできるようにしている場合は zabbix_url にその URLを設定するほうが良いでしょう。
+
+参考：https://qiita.com/migaras/items/bc0dde421af9650d109c

--- a/hive_builder/playbooks/roles/docker-client/templates/dexec
+++ b/hive_builder/playbooks/roles/docker-client/templates/dexec
@@ -40,15 +40,17 @@ suffix={{ hive_name }}
 # (ex. name=dhcp is matching for dhcp and dhcpdb)
 # num_replicas=$(docker service ls --format '{{.Replicas}}' --filter "name=$1" | cut -f 1 -d /)
 num_replicas=$(docker service ls --format '{{.Name}} {{.Replicas}}' | awk '$1 == "'$1'" {cnt = split($2, r, "/");print r[1]}')
-if [ -z $num_replicas ]; then
+if [ -z "$num_replicas" ]; then
   error "service $1 is not found."
 fi
 if [ ${no_arg} -gt $num_replicas ]; then
   error "the index ${no_arg} exceed the nubmer of replicas of the service $num_replicas."
 fi
 set -eo pipefail
-if docker_command=$(docker service ps "$1" --format "docker -H tcp://{{.Node}}.$suffix:2376 exec $exec_opts {{.Name}}.{{.ID}}" --filter desired-state=running --no-trunc | head -$no_arg | tail -1); then
-  shift
-  exec $docker_command "$@"
+docker_command=$(docker service ps "$1" --format "docker -H tcp://{{.Node}}.$suffix:2376 exec $exec_opts {{.Name}}.{{.ID}}" --filter desired-state=running --no-trunc | head -$no_arg | tail -1)
+if [ -z "$docker_command" ]; then
+  error "the service $1 is not runing"
 fi
+shift
+exec $docker_command "$@"
 {% endraw %}

--- a/hive_builder/playbooks/roles/zabbix/files/Template_App_systemd_Services.xml
+++ b/hive_builder/playbooks/roles/zabbix/files/Template_App_systemd_Services.xml
@@ -37,7 +37,7 @@
                   <triggers>
                       <trigger>
                           <expression>{last()}&gt;0</expression>
-                          <name>Some service status are failed</name>
+                          <name>At least one of the services is in a failed state</name>
                           <priority>HIGH</priority>
                           <manual_close>YES</manual_close>
                       </trigger>

--- a/hive_builder/playbooks/roles/zabbix/files/hive-repository-server.xml
+++ b/hive_builder/playbooks/roles/zabbix/files/hive-repository-server.xml
@@ -129,7 +129,7 @@
                             <trigger_prototypes>
                                 <trigger_prototype>
                                     <expression>{last(#1)}&gt;0</expression>
-                                    <name>Some service in standalone type container {#SERVICE_NAME} was failed</name>
+                                    <name>At least one of the services in standalone type container {#SERVICE_NAME} is in a failed state</name>
                                     <priority>WARNING</priority>
                                 </trigger_prototype>
                             </trigger_prototypes>


### PR DESCRIPTION
- When the service specified by dexec is in the middle of starting, the  command is executed on the host.
- change the zabbix trigger title "Some service status are failed" to "At least one of the services is in a failed state"