### PR TITLE
[Fix] fail to set selinux mode on aws linux

### DIFF
--- a/examples/pdns/inventory/hive.yml
+++ b/examples/pdns/inventory/hive.yml
@@ -41,7 +41,7 @@ stages:
   #   cidr: 192.168.0.0/24
   #   instance_type: n1-standard-2
   #   region: asia-northeast2
-  # 　　　　disk_size: 100
-  # 　　　　repository_disk_size: 150
+  #   disk_size: 100
+  #   repository_disk_size: 150
   #   mirrored_disk_size: 20
   #   repository_instance_type: n1-standard-2

--- a/hive_builder/playbooks/roles/aws/tasks/build-aws.yml
+++ b/hive_builder/playbooks/roles/aws/tasks/build-aws.yml
@@ -69,7 +69,7 @@
 
 - name: create key pair using key_material obtained using 'file' lookup plugin
   ec2_key:
-    name: "{{ hive_aws_key_name | default('awsroot') }}"
+    name: "{{ hive_aws_key_name | default('hive-bulder-' + hive_name) }}"
     region: "{{ hive_region }}"
     key_material: "{{ lookup('file', hive_safe_public_key_path) }}"
 

--- a/hive_builder/playbooks/roles/aws/tasks/build-aws.yml
+++ b/hive_builder/playbooks/roles/aws/tasks/build-aws.yml
@@ -79,7 +79,7 @@
   loop_control:
     loop_var: aws_host
 
-- name: Create EFS file system
+- name: create EFS file system
   efs:
     state: present
     name: "efs-{{ hive_name }}"

--- a/hive_builder/playbooks/roles/aws/tasks/destroy-aws.yml
+++ b/hive_builder/playbooks/roles/aws/tasks/destroy-aws.yml
@@ -28,7 +28,7 @@
   register: hive_safe_eip
   loop: "{{ hive_safe_instances.results | map(attribute='instances') | flatten | selectattr('public_ip_address', 'defined') | map(attribute='public_ip_address') | difference(hive_safe_hosts | map('extract', hostvars) | selectattr('hive_published_ip', 'defined') | map(attribute='hive_published_ip') | list) | list }}"
 
-- name: Delete EFS file system
+- name: delete EFS file system
   efs:
     state: absent
     name: "efs-{{ hive_name }}"
@@ -37,6 +37,12 @@
       Name: "efs-{{ hive_name }}"
       Project: "{{ hive_name }}"
   when: (groups['nfs_volumes'] | intersect(groups[hive_stage]) | length) > 0
+
+- name: delete key pair
+  ec2_key:
+    name: "{{ hive_aws_key_name | default('hive-bulder-' + hive_name) }}"
+    region: "{{ hive_region }}"
+    state: absent
 
 - name: get vpc info
   ec2_vpc_net_info:

--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -66,9 +66,7 @@
     state: "{{ hive_safe_selinux }}"
   notify: require reboot
   vars:
-    ansible_interpreter_python_fallback:
-    - /usr/bin/python
-    - /usr/bin/python3
+    ansible_python_interpreter: "{{ '/usr/bin/python if ansible_distribution == 'Amazon' else '/usr/bin/python3' }}"
 - name: enable services
   service: "name={{ item }} enabled=yes state=started"
   with_items:

--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -65,6 +65,8 @@
     policy: targeted
     state: "{{ hive_safe_selinux }}"
   notify: require reboot
+  vars:
+    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else omit }}"
 - name: enable services
   service: "name={{ item }} enabled=yes state=started"
   with_items:

--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -66,7 +66,7 @@
     state: "{{ hive_safe_selinux }}"
   notify: require reboot
   vars:
-    ansible_python_interpreter: "{{ '/usr/bin/python if ansible_distribution == 'Amazon' else '/usr/bin/python3' }}"
+    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else '/usr/bin/python3' }}"
 - name: enable services
   service: "name={{ item }} enabled=yes state=started"
   with_items:

--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -66,7 +66,9 @@
     state: "{{ hive_safe_selinux }}"
   notify: require reboot
   vars:
-    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else omit }}"
+    ansible_interpreter_python_fallback:
+    - /usr/bin/python
+    - /usr/bin/python3
 - name: enable services
   service: "name={{ item }} enabled=yes state=started"
   with_items:

--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -138,9 +138,9 @@
 - name: check whether /etc/environment contains HTTP_PROXY
   command: "grep '^HTTP_PROXY=' /etc/environment"
   register: check_http_proxy
-  check_mode: no
-  failed_when: no
-  changed_when: no
+  check_mode: False
+  failed_when: False
+  changed_when: False
 - name: ensures /usr/lib/systemd/system/dnf-makecache.service.d dir exists
   file: path=/usr/lib/systemd/system/dnf-makecache.service.d state=directory
   when: check_http_proxy.rc == 0

--- a/hive_builder/variables_metainf.yml
+++ b/hive_builder/variables_metainf.yml
@@ -353,5 +353,5 @@ registry_backup_cleanup_days_before:
   name_in_ansible: hive_registry_backup_cleanup_days_before
 interpreter_python:
   description: "how to deside use which python interpretor"
-  default: auto_legacy_silent
+  default: auto_silent
   name_in_ansible_cfg: interpreter_python

--- a/hive_builder/variables_metainf.yml
+++ b/hive_builder/variables_metainf.yml
@@ -351,3 +351,7 @@ registry_backup_cleanup_days_before:
   type: int
   default: 3
   name_in_ansible: hive_registry_backup_cleanup_days_before
+interpreter_python:
+  description: "how to deside use which python interpretor"
+  default: auto_legacy_silent
+  name_in_ansible_cfg: interpreter_python


### PR DESCRIPTION
-  fail to set selinux mode on aws linux
- the default key named "awsroot" is overwrited every build-infra