### PR TITLE
[Fix]: problems on second execution of setup-hosts, other problems

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -79,7 +79,7 @@ WSL を公式サイト https://docs.microsoft.com/ja-jp/windows/wsl/install-win1
   ./configure --enable-optimizations
   make install
   apt install docker sshpass
-  apt docker.io
+  apt install docker.io
 
 ansible でサーバへのログインに使用する ssh 鍵のファイルについて、
 owner は自分で modeは 0400 となっていて、他人から参照できない状態である必要があります。

--- a/docs/vagrant.rst
+++ b/docs/vagrant.rst
@@ -141,7 +141,7 @@ VirtualBox を公式サイト https://www.virtualbox.org/に従って Windows �
 
 ::
 
-    wget https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.16_x86_64.deb
+    wget https://releases.hashicorp.com/vagrant/2.2.16/vagrant_2.2.16_x86_64.deb
     dpkg -i vagrant_2.2.16_x86_64.deb
     vagrant plugin install vagrant-disksize
 

--- a/examples/pdns/inventory/hive.yml
+++ b/examples/pdns/inventory/hive.yml
@@ -4,7 +4,7 @@ stages:
   private:
     provider: vagrant
     separate_repository: False
-    cidr: 192.168.0.96/27
+    cidr: 192.168.56.0/27
     memory_size: 4096
     number_of_hosts: 1
   staging:

--- a/examples/pdns/lib/powerdns_record.py
+++ b/examples/pdns/lib/powerdns_record.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 DOCUMENTATION = '''

--- a/examples/pdns/lib/powerdns_zone.py
+++ b/examples/pdns/lib/powerdns_zone.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 DOCUMENTATION = '''

--- a/hive_builder/playbooks/roles/aws/tasks/create_instance.yml
+++ b/hive_builder/playbooks/roles/aws/tasks/create_instance.yml
@@ -38,7 +38,7 @@
     vpc_subnet_id: "{{ ( hive_safe_subnets_info.results | selectattr('item.name', 'equalto', hostvars[aws_host].hive_subnet) | first).subnet.id }}"
     image_id: "{{ hive_safe_image_id }}"
     instance_type: "{{ hostvars[aws_host].hive_instance_type }}"
-    key_name: "{{ hive_aws_key_name | default('awsroot') }}"
+    key_name: "{{ hive_aws_key_name | default('hive-bulder-' + hive_name) }}"
     volumes: "{{ hive_safe_disks }}"
     network:
       assign_public_ip: False

--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -66,7 +66,7 @@
     state: "{{ hive_safe_selinux }}"
   notify: require reboot
   vars:
-    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else ansible_facts.python.executable }}"
+    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else '/usr/libexec/platform-python' }}"
 - name: enable services
   service: "name={{ item }} enabled=yes state=started"
   with_items:

--- a/hive_builder/playbooks/roles/docker/tasks/main.yml
+++ b/hive_builder/playbooks/roles/docker/tasks/main.yml
@@ -45,6 +45,7 @@
       - "libseccomp{{ libsecomp_version }}.*"
       - docker-ce
     state: present
+    exclude: "*.i686"
   when: ansible_distribution != 'Amazon'
   # AWS linux provides docker ce in amazon extra repos
 - name: install docker package

--- a/hive_builder/playbooks/roles/zabbix-agent/tasks/main.yml
+++ b/hive_builder/playbooks/roles/zabbix-agent/tasks/main.yml
@@ -43,6 +43,8 @@
     state: latest
   args:
     chdir: /var/lib/zabbix
+  vars:
+    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else '/usr/libexec/platform-python' }}"
 - name: set PyPi index url for zabbix
   become_user: zabbix
   copy:
@@ -51,7 +53,7 @@
       index-url = {{ hive_pip_index_url }}
     dest: /var/lib/zabbix/docker/pip.conf
   when: hive_pip_index_url is defined
-- name: create virtual env for zabbix
+- name: install python pacages for zabbix
   become_user: zabbix
   pip:
     name:
@@ -63,6 +65,8 @@
     state: present
   args:
     chdir: /var/lib/zabbix
+  vars:
+    ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else '/usr/libexec/platform-python' }}"
 - name: "setup tls connection - put ca certs"
   copy:
     src: "{{ hive_safe_ca_dir }}/cacert.pem"

--- a/hive_builder/requirements.yml
+++ b/hive_builder/requirements.yml
@@ -6,7 +6,6 @@ collections:
  - community.crypto
  - community.general
  - name: community.docker
-   version: 2.2.1
  - community.zabbix
  - community.aws
  - amazon.aws


### PR DESCRIPTION
**Documents:**
- Fixed a typo in the command to install Docker on WSL
- Fixed vagrant media download path to the latest version

**Examples:**
- Match private cidr to VirtualBox default
- Fixed the problem that "can't execute'python': No such file or directory" error occurred.

**install-collection command:**
- Fixed an issue where unix: // {{": invalid character "{" in host name error occurred in build-images

**Playbooks:**
- Fixed the problem that error occurs in selinux setting and zabbix-agent setting in the second setup-hosts.
- Fixed an issue that caused "Failed to connect to the host via ssh: ec2-user@176.32.69.212: Permission denied" error on aws ssh connection
- Fixed an issue where RHEL would install the i686 version of libseccomp