### PR TITLE
Change dcp to dexec

### DIFF
--- a/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
+++ b/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
@@ -27,7 +27,7 @@ function backup_{{ hive_safe_target }}() {
         {%- if hive_safe_backup_script.backup_file is defined %}
 
   if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.backup_command }}' 1>&2 ; then
-    dcp {{ hive_safe_target }}:{{ hive_safe_backup_script.backup_file }} $backup_file
+    dexec -n {{ hive_safe_target }} tar cf - -C $(dirname {{ hive_safe_backup_script.backup_file }}) $(basename {{ hive_safe_backup_script.backup_file }}) | tar -O -xf - | cat > $backup_file
         {%- else %}
 
   if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.backup_command }}' > "$backup_file"; then
@@ -67,7 +67,7 @@ function restore_{{ hive_safe_target }}() {
       {%- if hive_safe_backup_script.restore_command is defined %}
         {%- if hive_safe_backup_script.restore_file is defined %}
 
-    dcp -L $backup_file {{ hive_safe_target }}:{{ hive_safe_backup_script.restore_file }}
+    tar cf - -h -C $(dirname $backup_file) $(basename $backup_file) | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c 'cat > {{ hive_safe_backup_script.restore_file }}'
     if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.restore_command }}'  ; then
         {%- else %}
 
@@ -75,7 +75,7 @@ function restore_{{ hive_safe_target }}() {
         {%- endif %}
         {%- elif hive_safe_backup_script.directory is defined %}
 
-    dcp -L $backup_file {{ hive_safe_target }}:{{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz
+    tar cf - -h -C $(dirname $backup_file) $(basename $backup_file) | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c "cat > {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz"
     if dexec -n {{ hive_safe_target }} sh -c 'cd {{hive_safe_backup_script.directory}}; rm -rf $(find . -maxdepth 1 -not -name .); tar xzf {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz'; then
       {%- endif %}
 

--- a/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
+++ b/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
@@ -27,7 +27,7 @@ function backup_{{ hive_safe_target }}() {
         {%- if hive_safe_backup_script.backup_file is defined %}
 
   if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.backup_command }}' 1>&2 ; then
-    # In the case hive_safe_backup_script.backup_file is directory, problems may occur.
+    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. #}
     dexec -n {{ hive_safe_target }} tar cf - {{ hive_safe_backup_script.backup_file }} | tar -O -xf - | cat > $backup_file
         {%- else %}
 
@@ -68,7 +68,7 @@ function restore_{{ hive_safe_target }}() {
       {%- if hive_safe_backup_script.restore_command is defined %}
         {%- if hive_safe_backup_script.restore_file is defined %}
 
-    # In the case hive_safe_backup_script.backup_file is directory, problems may occur.
+    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. #}
     tar cf - -h $backup_file | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c 'cat > {{ hive_safe_backup_script.restore_file }}'
     if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.restore_command }}'  ; then
         {%- else %}
@@ -77,7 +77,7 @@ function restore_{{ hive_safe_target }}() {
         {%- endif %}
         {%- elif hive_safe_backup_script.directory is defined %}
 
-    # In the case hive_safe_backup_script.backup_file is directory, problems may occur.
+    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. #}
     tar cf - -h $backup_file | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c "cat > {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz"
     if dexec -n {{ hive_safe_target }} sh -c 'cd {{hive_safe_backup_script.directory}}; rm -rf $(find . -maxdepth 1 -not -name .); tar xzf {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz'; then
       {%- endif %}

--- a/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
+++ b/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
@@ -27,7 +27,7 @@ function backup_{{ hive_safe_target }}() {
         {%- if hive_safe_backup_script.backup_file is defined %}
 
   if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.backup_command }}' 1>&2 ; then
-    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. #}
+    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. -#}
     dexec -n {{ hive_safe_target }} tar cf - {{ hive_safe_backup_script.backup_file }} | tar -O -xf - | cat > $backup_file
         {%- else %}
 
@@ -68,7 +68,7 @@ function restore_{{ hive_safe_target }}() {
       {%- if hive_safe_backup_script.restore_command is defined %}
         {%- if hive_safe_backup_script.restore_file is defined %}
 
-    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. #}
+    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. -#}
     tar cf - -h $backup_file | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c 'cat > {{ hive_safe_backup_script.restore_file }}'
     if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.restore_command }}'  ; then
         {%- else %}
@@ -77,7 +77,7 @@ function restore_{{ hive_safe_target }}() {
         {%- endif %}
         {%- elif hive_safe_backup_script.directory is defined %}
 
-    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. #}
+    {# In the case hive_safe_backup_script.backup_file is directory, problems may occur. -#}
     tar cf - -h $backup_file | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c "cat > {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz"
     if dexec -n {{ hive_safe_target }} sh -c 'cd {{hive_safe_backup_script.directory}}; rm -rf $(find . -maxdepth 1 -not -name .); tar xzf {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz'; then
       {%- endif %}

--- a/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
+++ b/hive_builder/playbooks/roles/service-backup/templates/service-backup.sh.j2
@@ -27,7 +27,8 @@ function backup_{{ hive_safe_target }}() {
         {%- if hive_safe_backup_script.backup_file is defined %}
 
   if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.backup_command }}' 1>&2 ; then
-    dexec -n {{ hive_safe_target }} tar cf - -C $(dirname {{ hive_safe_backup_script.backup_file }}) $(basename {{ hive_safe_backup_script.backup_file }}) | tar -O -xf - | cat > $backup_file
+    # In the case hive_safe_backup_script.backup_file is directory, problems may occur.
+    dexec -n {{ hive_safe_target }} tar cf - {{ hive_safe_backup_script.backup_file }} | tar -O -xf - | cat > $backup_file
         {%- else %}
 
   if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.backup_command }}' > "$backup_file"; then
@@ -67,7 +68,8 @@ function restore_{{ hive_safe_target }}() {
       {%- if hive_safe_backup_script.restore_command is defined %}
         {%- if hive_safe_backup_script.restore_file is defined %}
 
-    tar cf - -h -C $(dirname $backup_file) $(basename $backup_file) | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c 'cat > {{ hive_safe_backup_script.restore_file }}'
+    # In the case hive_safe_backup_script.backup_file is directory, problems may occur.
+    tar cf - -h $backup_file | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c 'cat > {{ hive_safe_backup_script.restore_file }}'
     if dexec -n {{ hive_safe_target }} sh -c '{{ hive_safe_backup_script.restore_command }}'  ; then
         {%- else %}
 
@@ -75,7 +77,8 @@ function restore_{{ hive_safe_target }}() {
         {%- endif %}
         {%- elif hive_safe_backup_script.directory is defined %}
 
-    tar cf - -h -C $(dirname $backup_file) $(basename $backup_file) | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c "cat > {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz"
+    # In the case hive_safe_backup_script.backup_file is directory, problems may occur.
+    tar cf - -h $backup_file | tar -O -xf - | dexec -n {{ hive_safe_target }} /bin/bash -c "cat > {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz"
     if dexec -n {{ hive_safe_target }} sh -c 'cd {{hive_safe_backup_script.directory}}; rm -rf $(find . -maxdepth 1 -not -name .); tar xzf {{ '/root' if (hostvars[hive_safe_target].hive_standalone | default(False)) else '/tmp' }}/restore.tar.gz'; then
       {%- endif %}
 


### PR DESCRIPTION
docker cp するたびに、コンテナ内のマウントパスの数が増え続けていくという事象が発生する。
その事象を、docker exec コマンドを使うことによって、マウントパスの数が増えることなく、 docker cp と同様のファイルを複製することで回避できる。

今回の hive-builder 内では、docker cp は dcp 、 docker exec は dexec を使うことができるので、dcp が使用されていた3ヶ所を dexec に置き換え、それに付随する修正をおこなった。

以上の修正に対するレビュー、よろしくお願いします。