### PR TITLE
install_rsyslog_in_base_role

### DIFF
--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -52,6 +52,7 @@
       - chrony
       - conntrack-tools
       - bash-completion
+      - rsyslog
       - "{{ 'libselinux-python' if ansible_distribution == 'Amazon' else 'python3-libselinux' }}"
 - name: install selinux packages
   yum:


### PR DESCRIPTION
rsyslog を hive-builder の base ロールでインストールするように編集しました。