### PR TITLE
localeの言語パッケージをglibc-commonからではなくlagpacksからインストールするように修正（el8化対応）

### DIFF
--- a/hive_builder/playbooks/roles/base/tasks/main.yml
+++ b/hive_builder/playbooks/roles/base/tasks/main.yml
@@ -92,18 +92,20 @@
 # setting up locale if hive_locale is defined
 - name: install packages for locale
   yum:
-    name: glibc-common
+    name: langpacks-{{ hive_locale | regex_replace('LANG=') | regex_replace('_.*') }}.noarch
     state: latest
   when: hive_locale is defined
 - name: gather locale info
-  command: localectl
+  shell: "localectl | grep Locale | sed -e 's/\\s*System Locale: //g'"
   check_mode: False
   changed_when: False
   register: hive_safe_current_locale
   when: hive_locale is defined
 - name: "set locale"
   shell: "localectl set-locale {{ hive_locale }}"
-  when: "hive_locale is defined and not hive_safe_current_locale.stdout.find('System Locale: ' + hive_locale)"
+  when:
+  - "hive_locale is defined"
+  - "hive_locale is not in hive_safe_current_locale.stdout"
 # setting up sshd parameters
 - name: disable Password Authentication for sshd
   lineinfile:


### PR DESCRIPTION
el8からlocaleの言語パッケージがglibc-commonからではなく、使用する言語のみをlangpacksからインストールするように仕様が変更となったためhiveのhive_localeパラメータを修正。
localeを設定する場合は、all.ymlに下記のように設定する言語を指定する。
hive_locale: LANG=ja_JP.UTF-8