### PR TITLE
[[PRERELASE]] drbd for new kernel

### DIFF
--- a/hive_builder/playbooks/roles/docker-client/tasks/main.yml
+++ b/hive_builder/playbooks/roles/docker-client/tasks/main.yml
@@ -36,7 +36,7 @@
 # $ pip list | grep docker
 # docker           5.0.0
 
-# avoid error in docker login task: Error connecting: Error while fetching server API version: request() got an unexpected keyword argument ''chunked''
+# 2023/05/05 avoid error in docker login task: Error connecting: Error while fetching server API version: request() got an unexpected keyword argument ''chunked''
 # https://github.com/docker/docker-py/issues/3113#issue-1685565058
 - name: install docker python module
   become: False

--- a/hive_builder/playbooks/roles/docker-client/tasks/main.yml
+++ b/hive_builder/playbooks/roles/docker-client/tasks/main.yml
@@ -35,10 +35,14 @@
 # Python 3.7.9
 # $ pip list | grep docker
 # docker           5.0.0
+
+# avoid error in docker login task: Error connecting: Error while fetching server API version: request() got an unexpected keyword argument ''chunked''
+# https://github.com/docker/docker-py/issues/3113#issue-1685565058
 - name: install docker python module
   become: False
   pip:
     name:
+    - "requests<2.29"
     - docker
     - six
     state: present

--- a/hive_builder/playbooks/roles/drbd/tasks/main.yml
+++ b/hive_builder/playbooks/roles/drbd/tasks/main.yml
@@ -22,7 +22,8 @@
         (
          'Latests/drbd-9.1.12-v9.22.0-4.18.0-372.32.1.el8.x86_64' if ansible_distribution_release == 'Ootpa'
          else 'Latests/drbd-9.1.12-v9.22.0-4.18.0-425.3.1.el8.x86_64' if uname_result.stdout == '4.18.0-425.3.1.el8.x86_64'
-         else 'Latests/drbd-9.1.12-v9.22.0-4.18.0-425.13.1.el8_7.x86_64'
+         else 'Latests/drbd-9.1.12-v9.22.0-4.18.0-425.13.1.el8_7.x86_64' if uname_result.stdout == '4.18.0-425.13.1.el8.x86_64'
+         else 'Latests/drbd-9.2.3-v9.22.0-4.18.0-425.19.2.el8_7.x86_64'
         ) ) + '.tar.gz') }}
     dest: /root/drbd9-rpm.tar.gz
 - name: extract drbd rpm files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hive-builder"
-version = "3.6.6rc1"
+version = "3.6.6rc2"
 description = "Building docker swarm environment"
 authors = ["Mitsuru Nakakawaj <mitsuru@procube.jp>"]
 license = "MIT"


### PR DESCRIPTION
- load drbd version drbd-9.2.3-v9.22.0-4.18.0-425.19.2 for new AlmaLinux 8.7
- avoid error in docker login task: Error connecting: Error while fetching server API version: request() got an unexpected keyword argument ''chunked'' (https://github.com/docker/docker-py/issues/3113)
