### PR TITLE
pip upgradeタスクを同時に実行せずに、1台ずつ実行するように修正

### DIFF
--- a/hive_builder/playbooks/roles/docker-client/tasks/main.yml
+++ b/hive_builder/playbooks/roles/docker-client/tasks/main.yml
@@ -47,6 +47,7 @@
     - six
     state: present
     virtualenv: "{{ hive_home_dir }}/docker"
+  throttle: 1
 - name: install utility comnand
   template:
     dest: /usr/bin/{{ item }}

--- a/hive_builder/playbooks/roles/pip-venv/tasks/main.yml
+++ b/hive_builder/playbooks/roles/pip-venv/tasks/main.yml
@@ -33,7 +33,7 @@
       - setuptools
       - wheel
     virtualenv: "{{ hive_home_dir }}/docker"
-    virtualenv_command: python3 -m venv
+    virtualenv_command: "python{{ hive_safe_python_revision }} -m venv"
     # hive-builder does not require libselinux module,
     # but inherit system site-pacakges for addon which requires libselinux module
     virtualenv_site_packages: "{{ hive_safe_need_libselinux }}"
@@ -41,6 +41,7 @@
     state: latest
   args:
     chdir: "{{ hive_home_dir }}"
+  throttle: 1
 - name: install python-dxf
   become: False
   pip:
@@ -49,6 +50,7 @@
     virtualenv: "{{ hive_home_dir }}/docker"
   args:
     chdir: "{{ hive_home_dir }}"
+  throttle: 1
 - name: setup auto enter virtualenv at login
   become: False
   lineinfile:

--- a/hive_builder/playbooks/roles/zabbix-agent/tasks/main.yml
+++ b/hive_builder/playbooks/roles/zabbix-agent/tasks/main.yml
@@ -38,7 +38,7 @@
       - wheel
     virtualenv: /var/lib/zabbix/docker
     # virtualenv_python: "{{ hive_safe_python_command }}"
-    virtualenv_command: python3 -m venv
+    virtualenv_command: "python{{ hive_safe_python_revision }} -m venv"
     # hive-builder does not require libselinux module,
     # but inherit system site-pacakges for addon which requires libselinux module
     virtualenv_site_packages: "{{ hive_safe_need_libselinux }}"
@@ -48,6 +48,7 @@
     chdir: /var/lib/zabbix
   vars:
     ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else '/usr/libexec/platform-python' }}"
+  throttle: 1
 - name: install python pacages for zabbix
   become_user: zabbix
   pip:
@@ -62,6 +63,7 @@
     chdir: /var/lib/zabbix
   vars:
     ansible_python_interpreter: "{{ '/usr/bin/python' if ansible_distribution == 'Amazon' else '/usr/libexec/platform-python' }}"
+  throttle: 1
 - name: "setup tls connection - put ca certs"
   copy:
     src: "{{ hive_safe_ca_dir }}/cacert.pem"


### PR DESCRIPTION
# What
pip upgradeタスクを同時に実行せずに、1台ずつ実行するように修正
# Why
pip upgradeタスクを全ホストに対して同時に実行した場合、pip が正常にアップグレードできないホストが生じるため、修正した。