### PR TITLE
kickstartプロバイダの場合に、ssh接続できるようにするタスクを追加

### DIFF
--- a/hive_builder/playbooks/roles/ssh-connection/tasks/main.yml
+++ b/hive_builder/playbooks/roles/ssh-connection/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: connect to servers
+  wait_for_connection:
+    timeout: 20

--- a/hive_builder/playbooks/setup-hosts.yml
+++ b/hive_builder/playbooks/setup-hosts.yml
@@ -3,6 +3,17 @@
   hosts: servers
   become: True
   tags: setup-hosts
+  vars:
+    ansible_ssh_common_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile={{ hive_context_dir }}/known_hosts"
+  roles:
+    - role: ssh-connection
+      tags: [ 'ssh-connection' ]
+      when: hive_provider == 'kickstart'
+
+- name: setup hive servers
+  hosts: servers
+  become: True
+  tags: setup-hosts
 
   pre_tasks:
     # avoid error "The task includes an option with an undefined variable.


### PR DESCRIPTION
# What
kickstartプロバイダの場合に、ssh接続できるようにするタスクを追加
# Why
kickstart 以外のプロバイダを選択した場合は、build-infra のフェーズで `StrictHostKeyChecking=no` オプションを使用して ssh 接続できる。
しかし、kickstart プロバイダの場合は、build-infra のフェーズではホストがまだ構築されていない。
そのため、kickstart プロバイダの場合は、setup-hosts の最初で `StrictHostKeyChecking=no` オプションを使用して ssh 接続するようにタスクを追加した。