### PR TITLE
プロキシ環境下での構築のドキュメント部分の修正

### DIFF
--- a/docs/proxy.rst
+++ b/docs/proxy.rst
@@ -112,13 +112,25 @@ dockerhub のアカウントにログインするためのユーザIDとパス�
 ::
 
     cd オフラインキャッシュサーバのディレクトリ
-    ansible-playbook -i squid,registry,devpi-server,nginx offline.yml 
+    ansible-playbook -i squid,registry,devpi-server,nginx, offline.yml 
 
 
 6. 再ビルド
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 この mother 環境があれば、オフラインの状態で全サーバをOSインストールから再構築( hive all )することができます。
+
+
+7. squid コンテナの hosts ファイルの再設定
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+マザーマシンを再起動した場合など、squid コンテナの hosts ファイルの設定と、コンテナの実際の IP アドレスのズレが発生する場合があります。
+以下のコマンドで squid コンテナの hosts ファイルの再設定を行い、IP アドレスのズレを解消することができます。
+
+::
+
+    cd オフラインキャッシュサーバのディレクトリ
+    ansible-playbook -i squid, reset-squid-hosts.yml
 
 
 vagrant プロバイダの場合


### PR DESCRIPTION
オフラインキャッシュサーバを使用する場合、マザーマシンを再起動すると、docker-compose で起動したコンテナのIPが変わり、squid コンテナの hosts ファイルの設定とコンテナのIPとのずれが発生します。
squid コンテナの hosts ファイルの設定とコンテナのIPとのずれを解消するための playbook をオフラインキャッシュに実装したため、その ansible コマンドの実行方法を「プロキシ環境下での構築」に追記しました。