### PR TITLE
Fix/3.7.4/follow swarm service

### DIFF
--- a/hive_builder/playbooks/roles/follow-swarm-service/tasks/main.yml
+++ b/hive_builder/playbooks/roles/follow-swarm-service/tasks/main.yml
@@ -27,6 +27,13 @@
 - name: Apply new SELinux file context to filesystem
   command: "restorecon -irv {{ hive_home_dir }}/docker/bin/python*"
   when: hive_safe_selinux != 'disabled' and (result_sefcontext_l is changed or result_sefcontext_f is changed)
+- name: install scapy
+  pip:
+    name:
+      - scapy
+    virtualenv: "{{ hive_home_dir }}/docker"
+  args:
+    chdir: "{{ hive_home_dir }}"
 - name: setup follow swarm service service
   template:
     src: follow-swarm-service.service


### PR DESCRIPTION
follow-swarm-serviceにおいて、サービスデプロイ時やフェールオーバー時に、ICMPv6のNeighbor Advertisementを送信する機能を追加する。scapyモジュールを使用するためfollow-swarm-serviceロールにて、モジュールのインストールも実施する。