### PR TITLE
includeの場所を最後に修正

### DIFF
--- a/hive_builder/playbooks/roles/rsyslogd/templates/services.conf
+++ b/hive_builder/playbooks/roles/rsyslogd/templates/services.conf
@@ -15,7 +15,6 @@ module(
 {% else %}
 module(load="imudp")
 {% endif %}
-include(file="/etc/rsyslog-services.d/*.conf")
 
 template(name="pathForService" type="string" string="/var/log/services/%APP-NAME%.log")
 template(name="pathForStandalone" type="string" string="/var/log/services/%HOSTNAME%.log")
@@ -43,3 +42,4 @@ input(
   port="{{ hive_safe_syslog_port }}"
   ruleset="docker"
 )
+include(file="/etc/rsyslog-services.d/*.conf")

--- a/hive_builder/playbooks/roles/rsyslogd/templates/services.conf
+++ b/hive_builder/playbooks/roles/rsyslogd/templates/services.conf
@@ -35,6 +35,7 @@ ruleset(name="docker") {
   } else {
     action(type="omfile" file="/var/log/service-other-facility.log" template="logFormatOther" action.copyMsg="on")
   }
+  include(file="/etc/rsyslog-services.d/*.conf")
 }
 
 input(
@@ -42,4 +43,3 @@ input(
   port="{{ hive_safe_syslog_port }}"
   ruleset="docker"
 )
-include(file="/etc/rsyslog-services.d/*.conf")


### PR DESCRIPTION
rsyslogdで以下のエラーが発生していた。
`rsyslogd[138281]:  Could not find template 0 'logFormatErrorApp' - action disabled [v8.2310.0-4.el9 try https://www.rsyslog.com/e/3003 ]`
原因は、修正の通り、templateの定義の前にconfをincludeしていることであった。
修正により、エラーが出ず、rsyslogdを起動できることを確認した。