### PR TITLE
Entrypointの有無に左右されない形に変数へのアクセス方法を修正

### DIFF
--- a/hive_builder/playbooks/push-image.yml
+++ b/hive_builder/playbooks/push-image.yml
@@ -13,11 +13,11 @@
     reset_build_overrides: ""
 - set_fact:
     # --change 'ENTRYPOINT []' does not set null, so set ["/bin/sh","-c","exec \"$@\"","--"]
-    reset_build_overrides: "{{reset_build_overrides}} --change 'ENTRYPOINT {% if hive_entrypoint is defined %}{{ hive_entrypoint | to_json }}{% elif orig_config.Entrypoint == none %}[\"/bin/sh\",\"-c\",\"exec \\\"$@\\\"\",\"--\"]{% else %}{{ orig_config.Entrypoint | to_json }}{% endif %}'"
+    reset_build_overrides: "{{reset_build_overrides}} --change 'ENTRYPOINT {% if hive_entrypoint is defined %}{{ hive_entrypoint | to_json }}{% elif orig_config.Entrypoint is defined and orig_config.Entrypoint != none %}{{ orig_config.Entrypoint | to_json }}{% else %}[\"/bin/sh\",\"-c\",\"exec \\\"$@\\\"\",\"--\"]{% endif %}'"
   when: not (hive_standalone | default(False))
 - set_fact:
     # --change CMD cannot set null, so set []
-    reset_build_overrides: "{{reset_build_overrides}} --change 'CMD {% if hive_command is defined %}{{ hive_command | to_json }}{% elif orig_config.Cmd == none %}[]{% else %}{{ orig_config.Cmd | to_json }}{% endif %}'"
+    reset_build_overrides: "{{reset_build_overrides}} --change 'CMD {% if hive_command is defined %}{{ hive_command | to_json }}{% elif orig_config.Cmd is defined and orig_config.Cmd != none %}{{ orig_config.Cmd | to_json }}{% else %}[]{% endif %}'"
   when: not (hive_standalone | default(False))
 - set_fact:
     # --change WORKDIR cannot set "", so set /


### PR DESCRIPTION
hive build-images実行時に、以下のエラーが発生する。
`FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'Entrypoint'. 'dict object' has no attribute 'Entrypoint'\n\nThe error appears to be in '/home/builder/hive/lib64/python3.9/site-packages/hive_builder/playbooks/push-image.yml': line 14, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n    reset_build_overrides: \"\"\n- set_fact:\n  ^ here\n"}`
原因は、全く同じイメージIDのイメージにおいても異なる環境でdocker image inspectを実行すると、Config.Entrypointがnullで定義されている場合と、そもそも未定義（存在しない）の場合があり、後者の場合に本修正箇所の変数へのアクセス方法に問題あり、上記のエラーとなっていた。（dockerのバージョンの違いが影響していると想定される）
本修正では、Config.Entrypointの有無に左右されないように変数へのアクセス方法を修正した。